### PR TITLE
Add CampsiteDTO and CampsiteTypeDTO for response shaping

### DIFF
--- a/Models/DTOs/CampsiteDTO.cs
+++ b/Models/DTOs/CampsiteDTO.cs
@@ -1,0 +1,10 @@
+namespace CreekRiver.DTOs;
+
+public class CampsiteDTO
+{
+    public int Id { get; set; }
+    public string?  Nickname { get; set; }
+    public string? ImageUrl { get; set; }
+    public int CampsiteTypeId { get; set; }
+    public CampsiteTypeDTO? CampsiteType { get; set; }
+}

--- a/Models/DTOs/CampsiteTypeDTO.cs
+++ b/Models/DTOs/CampsiteTypeDTO.cs
@@ -1,0 +1,9 @@
+namespace CreekRiver.DTOs;
+
+public class CampsiteTypeDTO
+{
+    public int Id { get; set; }
+    public string? CampsiteTypeName { get; set; }
+    public decimal FeePerNight { get; set; }
+    public int MaxReservationDays { get; set; }
+}

--- a/Models/UserProfile.cs
+++ b/Models/UserProfile.cs
@@ -6,12 +6,12 @@ public class UserProfile
 {
     public int Id { get; set; }
     [Required]
-    public string FirstName { get; set; }
+    public string? FirstName { get; set; }
     [Required]
-    public string LastName { get; set; }
+    public string? LastName { get; set; }
     [Required]
-    public string Email { get; set; }
+    public string? Email { get; set; }
 
-    public List<Reservation> Reservations { get; set; }
+    public List<Reservation>? Reservations { get; set; }
 
 }

--- a/Program.cs
+++ b/Program.cs
@@ -1,25 +1,25 @@
 using CreekRiver.Models;
+using CreekRiver.DTOs;
 using Microsoft.EntityFrameworkCore;
-using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http.Json;
-
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+// Enable Swagger/OpenAPI
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+// Enable legacy timestamp behavior for PostgreSQL
 AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
 
+// Register DbContext with connection string from secrets
 builder.Services.AddNpgsql<CreekRiverDbContext>(
     builder.Configuration["CreekRiverDbConnectionString"]);
 
-
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
+// Swagger UI only in development
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
@@ -28,29 +28,45 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-var summaries = new[]
-{
-    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-};
 
-app.MapGet("/weatherforecast", () =>
+// GET /api/campsites
+app.MapGet("/api/campsites", (CreekRiverDbContext db) =>
 {
-    var forecast =  Enumerable.Range(1, 5).Select(index =>
-        new WeatherForecast
-        (
-            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-            Random.Shared.Next(-20, 55),
-            summaries[Random.Shared.Next(summaries.Length)]
-        ))
-        .ToArray();
-    return forecast;
-})
-.WithName("GetWeatherForecast")
-.WithOpenApi();
+    return db.Campsites
+        .Select(c => new CampsiteDTO
+        {
+            Id = c.Id,
+            Nickname = c.Nickname,
+            ImageUrl = c.ImageUrl,
+            CampsiteTypeId = c.CampsiteTypeId
+        })
+        .ToList();
+});
+
+
+// GET /api/campsites/{id}
+app.MapGet("/api/campsites/{id}", (CreekRiverDbContext db, int id) =>
+{
+    var campsite = db.Campsites
+        .Include(c => c.CampsiteType)
+        .Select(c => new CampsiteDTO
+        {
+            Id = c.Id,
+            Nickname = c.Nickname,
+            ImageUrl = c.ImageUrl,
+            CampsiteTypeId = c.CampsiteTypeId,
+            CampsiteType = new CampsiteTypeDTO
+            {
+                Id = c.CampsiteType!.Id,  // 
+                CampsiteTypeName = c.CampsiteType.CampsiteTypeName,
+                FeePerNight = c.CampsiteType.FeePerNight,
+                MaxReservationDays = c.CampsiteType.MaxReservationDays
+            }
+        })
+        .SingleOrDefault(c => c.Id == id);
+
+    return campsite is null ? Results.NotFound() : Results.Ok(campsite);
+});
+
 
 app.Run();
-
-record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
-{
-    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
-}


### PR DESCRIPTION
# Add CampsiteDTO and CampsiteTypeDTO

## Summary

Introduces DTO classes for `Campsite` and `CampsiteType` to decouple internal EF models from API response formats.

## Details

- `CampsiteDTO` includes:
  - Basic campsite fields
  - Optional `CampsiteTypeDTO` when included by ID
- `CampsiteTypeDTO` contains public-facing metadata about the campsite type

## Why

Using DTOs allows for clearer, safer API responses and better separation between persistence and presentation concerns.
