### PR TITLE
Add POST /api/campsites endpoint for campsite creation

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -67,6 +67,13 @@ app.MapGet("/api/campsites/{id}", (CreekRiverDbContext db, int id) =>
 
     return campsite is null ? Results.NotFound() : Results.Ok(campsite);
 });
+// POST /api/campsites
+app.MapPost("/api/campsites", (CreekRiverDbContext db, Campsite campsite) =>
+{
+    db.Campsites.Add(campsite);
+    db.SaveChanges();
+    return Results.Created($"/api/campsites/{campsite.Id}", campsite);
+});
 
 
 app.Run();


### PR DESCRIPTION
# Add POST /api/campsites Endpoint

## Summary

Implements creation of new campsites via HTTP POST.

## Details

- Adds endpoint: `POST /api/campsites`
- Accepts a `Campsite` object in the request body
- Uses EF Core to insert a new row into the database
- Returns a `201 Created` response with location header and full campsite data

## Why

Completes the "Create" functionality for campsites, enabling dynamic data entry through the API.
