### PR TITLE
Add DELETE /api/campsites/{id} endpoint

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -42,7 +42,7 @@ app.MapGet("/api/campsites", (CreekRiverDbContext db) =>
         })
         .ToList();
 });
-
+ 
 
 // GET /api/campsites/{id}
 app.MapGet("/api/campsites/{id}", (CreekRiverDbContext db, int id) =>
@@ -73,6 +73,20 @@ app.MapPost("/api/campsites", (CreekRiverDbContext db, Campsite campsite) =>
     db.Campsites.Add(campsite);
     db.SaveChanges();
     return Results.Created($"/api/campsites/{campsite.Id}", campsite);
+});
+
+// DELETE /api/campsites/{id}
+app.MapDelete("/api/campsites/{id}", (CreekRiverDbContext db, int id) =>
+{
+    Campsite? campsite = db.Campsites.SingleOrDefault(c => c.Id == id);
+    if (campsite == null)
+    {
+        return Results.NotFound();
+    }
+
+    db.Campsites.Remove(campsite);
+    db.SaveChanges();
+    return Results.NoContent();
 });
 
 


### PR DESCRIPTION
# Add DELETE /api/campsites/{id} Endpoint

## Summary

Implements deletion of a campsite by ID.

## Details

- Uses `SingleOrDefault` to locate the campsite
- Returns `404 Not Found` if it doesn't exist
- Removes the entity and calls `SaveChanges`
- Returns `204 No Content` on success
- Cascade deletes any associated reservations

## Why

Supports clean and complete resource lifecycle for campsite management.
