### PR TITLE
Add Reservation Cost Calculation

### DIFF
--- a/Models/DTOs/ReservationDTO.cs
+++ b/Models/DTOs/ReservationDTO.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace CreekRiver.Models.DTOs;
 
 public class ReservationDTO
@@ -10,4 +12,12 @@ public class ReservationDTO
 
     public UserProfileDTO? UserProfile { get; set; }
     public CampsiteDTO? Campsite { get; set; }
+
+    // 👇 CALCULATED PROPERTIES
+
+    public int TotalNights => (CheckoutDate - CheckinDate).Days;
+
+    private static readonly decimal _reservationFee = 10M;
+
+    public decimal TotalCost => TotalNights * _reservationFee;
 }


### PR DESCRIPTION
Adds TotalNights and TotalCost calculated properties to ReservationDTO. Allows client to access these values in API responses without frontend logic.